### PR TITLE
Release 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Release 1.13.0
+
+Adding support for JSON path to the "I store" sentence.
+
+The JSON path can be used with:
+```
+$.firstElement[3].nextElement
+```
+
+The library detects, if the path has the prefix `$.`. If it is not available, it adds this prefix.
+
+
 # Release 1.12.0
 
 - Adding support for adding and manipulating headers.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.ragin.bdd
-version=1.12.0
+version=1.13.0
 
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github

--- a/src/main/java/com/ragin/bdd/cucumber/glue/ThenRESTValidationGlue.java
+++ b/src/main/java/com/ragin/bdd/cucumber/glue/ThenRESTValidationGlue.java
@@ -1,5 +1,7 @@
 package com.ragin.bdd.cucumber.glue;
 
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import com.ragin.bdd.cucumber.core.BaseCucumberCore;
 import com.ragin.bdd.cucumber.core.ScenarioStateContext;
 import io.cucumber.java.en.Then;
@@ -94,9 +96,15 @@ public class ThenRESTValidationGlue extends BaseCucumberCore {
         JsonObject json = jsonReader.readObject();
         jsonReader.close();
 
+        String jsonPath = fieldName;
+        if (! jsonPath.startsWith("$.")) {
+            jsonPath = "$." + jsonPath;
+        }
+        final DocumentContext documentContext = JsonPath.parse(ScenarioStateContext.current().getLatestResponse().getBody());
+        String field = documentContext.read(jsonPath, String.class);
         ScenarioStateContext.current().getScenarioContextMap().put(
                 replaceTrailingAndLeadingQuotes(contextName),
-                json.getJsonString(fieldName).getString()
+                field
         );
     }
 


### PR DESCRIPTION
Adding support for JSON path to the "I store" sentence.

The JSON path can be used with:
```
$.firstElement[3].nextElement
```

The library detects if the path has the prefix `$.`. If it is not available, it adds this prefix.
