### PR TITLE
Dependency Update and pattern support for isValidDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Release 1.21.0
+## Dependencies
+Update of dependencies and Cucumber library 6.8.1.
+
+## Add own patterns for `${json-unit.matches:isValidDate}`
+To add own `DateTimeFormatter` patterns to extend the `${json-unit.matches:isValidDate}` range
+a new class is required that implements the interface `BddCucumberDateTimeFormat`.
+The method `pattern()` must return the date patterns as `List<String>`.
+
+To register this custom class it is necessary to add it `@ContextConfiguration` `classes` definition.
+
+Example:
+
+- [Configuration context](src/test/java/com/ragin/bdd/cucumbertests/hooks/CreateContextHooks.java)
+- [Test feature](src/test/resources/features/body_validation/field_compare.feature)
+
 # Release 1.20.7
 Added new DateFormatter for database comparison: `yyyy-MM-dd HH:mm:ss.SSSSSS`.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ dependencies {
       - [Database data comparison](#database-data-comparison)
   - [REST](#rest)
     - [JSON-Unit](#json-unit)
+      - [Adding own pattern for `${json-unit.matches:isValidDate}`](#adding-own-pattern-for-json-unitmatchesisvaliddate)
     - [Given](#given-1)
       - [Define user(s)](#define-users)
       - [Set path base directory for request/result/database files](#set-path-base-directory-for-requestresultdatabase-files)
@@ -256,6 +257,20 @@ For the comparison of the results the library uses `JSON` files, which can be en
 - ...
 
 **_ATTENTION: Only unparameterized custom matchers or bdd lib-matchers can be used for field validation!_**
+
+#### Adding own pattern for `${json-unit.matches:isValidDate}`
+
+To add own `DateTimeFormatter` patterns to extend the `${json-unit.matches:isValidDate}` range
+a new class is required that implements the interface `BddCucumberDateTimeFormat`.
+The method `pattern()` must return the date patterns as `List<String>`.
+
+To register this custom class it is necessary to add it `@ContextConfiguration` `classes` definition.
+
+Example:
+
+- [Configuration context](src/test/java/com/ragin/bdd/cucumbertests/hooks/CreateContextHooks.java)
+- [Test feature](src/test/resources/features/body_validation/field_compare.feature)
+
 
 ### Given
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,39 +15,38 @@ apply plugin: 'io.spring.dependency-management'
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:2.3.1.RELEASE"
+        mavenBom "org.springframework.boot:spring-boot-dependencies:2.3.4.RELEASE"
     }
 }
 
 dependencies {
-    api 'org.apache.httpcomponents:httpclient'
-    api 'org.glassfish:javax.json:1.1.4'
-    api 'net.javacrumbs.json-unit:json-unit:2.19.0'
+    api "org.apache.httpcomponents:httpclient"
+    api "org.glassfish:javax.json:${versionJavaxJson}"
+    api "net.javacrumbs.json-unit:json-unit:${versionJsonUnit}"
 
-    api 'io.cucumber:cucumber-java:6.6.1'
-    api 'io.cucumber:cucumber-spring:6.6.1'
-    api 'io.cucumber:cucumber-junit:6.6.1'
+    api "io.cucumber:cucumber-java:${versionCucumber}"
+    api "io.cucumber:cucumber-spring:${versionCucumber}"
+    api "io.cucumber:cucumber-junit:${versionCucumber}"
 
-    api 'javax.validation:validation-api:2.0.1.Final'
+    api "javax.validation:validation-api:${versionValidationApi}"
 
-    api 'org.apache.commons:commons-text:1.9'
+    api "org.apache.commons:commons-text:${versionCommonsText}"
 
-    implementation 'org.liquibase:liquibase-core'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation "org.liquibase:liquibase-core"
+    implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-test"
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv"
 
-    implementation 'commons-io:commons-io:2.7'
-    implementation 'org.apache.commons:commons-lang3:3.11'
-    compileOnly 'org.projectlombok:lombok:1.18.12'
-    annotationProcessor 'org.projectlombok:lombok:1.18.12'
+    implementation "commons-io:commons-io:${versionCommonsIo}"
+    implementation "org.apache.commons:commons-lang3:${versionCommonsLang3}"
+    compileOnly "org.projectlombok:lombok:${versionLombok}"
+    annotationProcessor "org.projectlombok:lombok:${versionLombok}"
 
-    testCompileOnly 'org.projectlombok:lombok:1.18.12'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
-    testImplementation 'com.h2database:h2:1.4.200'
-    testImplementation 'junit:junit:4.13'
+    testCompileOnly "org.projectlombok:lombok:${versionLombok}"
+    testAnnotationProcessor "org.projectlombok:lombok:${versionLombok}"
+    testImplementation "com.h2database:h2:${versionH2}"
 }
 
 def pomConfig = {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,14 @@ version=1.20.7
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github
 systemProp.sonar.projectKey=Ragin-LundF_bbd-cucumber-gherkin-lib
+
+versionJavaxJson=1.1.4
+versionJsonUnit=2.21.0
+versionCucumber=6.8.1
+versionValidationApi=2.0.1.Final
+versionCommonsText=1.9
+versionCommonsIo=2.8.0
+versionCommonsLang3=3.11
+versionLombok=1.18.16
+
+versionH2=1.4.200

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.ragin.bdd
-version=1.20.6
+version=1.20.7
 
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github

--- a/src/main/java/com/ragin/bdd/cucumber/datetimeformat/BddCucumberDateTimeFormat.java
+++ b/src/main/java/com/ragin/bdd/cucumber/datetimeformat/BddCucumberDateTimeFormat.java
@@ -1,0 +1,14 @@
+package com.ragin.bdd.cucumber.datetimeformat;
+
+import java.util.List;
+
+public interface BddCucumberDateTimeFormat {
+    /**
+     * Pattern to add to the Date(Time)Parser.
+     *
+     * @return List of patterns to add
+     */
+    default List<String> pattern() {
+        return null;
+    }
+}

--- a/src/main/java/com/ragin/bdd/cucumber/datetimeformat/BddCucumberDateTimeFormat.java
+++ b/src/main/java/com/ragin/bdd/cucumber/datetimeformat/BddCucumberDateTimeFormat.java
@@ -1,5 +1,6 @@
 package com.ragin.bdd.cucumber.datetimeformat;
 
+import java.util.Collections;
 import java.util.List;
 
 public interface BddCucumberDateTimeFormat {
@@ -9,6 +10,6 @@ public interface BddCucumberDateTimeFormat {
      * @return List of patterns to add
      */
     default List<String> pattern() {
-        return null;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/ragin/bdd/cucumber/matcher/ValidDateMatcher.java
+++ b/src/main/java/com/ragin/bdd/cucumber/matcher/ValidDateMatcher.java
@@ -1,6 +1,9 @@
 package com.ragin.bdd.cucumber.matcher;
 
+import com.ragin.bdd.cucumber.datetimeformat.BddCucumberDateTimeFormat;
 import com.ragin.bdd.cucumber.utils.DateUtils;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.springframework.stereotype.Component;
@@ -9,9 +12,12 @@ import org.springframework.stereotype.Component;
  * Matcher for valid date
  */
 @Component
+@RequiredArgsConstructor
 public class ValidDateMatcher extends BaseMatcher<Object> {
+    private final Collection<BddCucumberDateTimeFormat> dateTimeFormatCollection;
+
     public boolean matches(Object item) {
-        return DateUtils.isValidMandatoryDate(item);
+        return DateUtils.isValidMandatoryDate(item, dateTimeFormatCollection);
     }
 
     @Override

--- a/src/main/java/com/ragin/bdd/cucumber/utils/DateUtils.java
+++ b/src/main/java/com/ragin/bdd/cucumber/utils/DateUtils.java
@@ -27,6 +27,7 @@ public final class DateUtils {
      * <p>Transforms date also if it is in another timezone</p>
      *
      * @param dateObject    Object with date
+     * @param bddDateTimeFormats Collection of BddCucumberDateFormat classes
      * @return              true = valid | false = invalid
      */
     public static boolean isValidMandatoryDate(final Object dateObject,

--- a/src/main/java/com/ragin/bdd/cucumber/utils/DateUtils.java
+++ b/src/main/java/com/ragin/bdd/cucumber/utils/DateUtils.java
@@ -143,13 +143,16 @@ public final class DateUtils {
         if (bddDateTimeFormats != null && ! bddDateTimeFormats.isEmpty()) {
             bddDateTimeFormats.forEach(bddDateTimeFormat -> {
                 // Pattern
-                if (bddDateTimeFormat.pattern() != null && ! bddDateTimeFormat.pattern().isEmpty()) {
-                    bddDateTimeFormat.pattern().forEach(pattern -> {
-                        dateTimeFormatsResult.put(pattern, DateTimeFormatter.ofPattern(pattern));
-                    });
+                if (! bddDateTimeFormat.pattern().isEmpty()) {
+                    bddDateTimeFormat.pattern().forEach(
+                            pattern -> dateTimeFormatsResult.put(
+                                    pattern, DateTimeFormatter.ofPattern(pattern))
+                    );
                 }
             });
         }
         return dateTimeFormatsResult;
     }
+
+    private DateUtils() {}
 }

--- a/src/main/java/com/ragin/bdd/cucumber/utils/JsonUtils.java
+++ b/src/main/java/com/ragin/bdd/cucumber/utils/JsonUtils.java
@@ -6,6 +6,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import com.ragin.bdd.cucumber.BddLibConstants;
 import com.ragin.bdd.cucumber.core.ScenarioStateContext;
+import com.ragin.bdd.cucumber.datetimeformat.BddCucumberDateTimeFormat;
 import com.ragin.bdd.cucumber.matcher.BddCucumberJsonMatcher;
 import com.ragin.bdd.cucumber.matcher.ScenarioStateContextMatcher;
 import com.ragin.bdd.cucumber.matcher.UUIDMatcher;
@@ -32,6 +33,8 @@ import org.springframework.stereotype.Component;
 public final class JsonUtils {
     @Autowired(required = false)
     Collection<BddCucumberJsonMatcher> jsonMatcher;
+    @Autowired(required = false)
+    Collection<BddCucumberDateTimeFormat> bddCucumberDateTimeFormatter;
 
     /**
      * Assert that two JSON Strings are equal
@@ -67,7 +70,7 @@ public final class JsonUtils {
         // base configuration
         Configuration configuration = JsonAssert.withTolerance(0)
                 .when(TREATING_NULL_AS_ABSENT)
-                .withMatcher("isValidDate", new ValidDateMatcher())
+                .withMatcher("isValidDate", new ValidDateMatcher(bddCucumberDateTimeFormatter))
                 .withMatcher("isValidUUID", new UUIDMatcher())
                 .withMatcher("isEqualToScenarioContext", new ScenarioStateContextMatcher());
 

--- a/src/test/java/com/ragin/bdd/cucumbertests/hooks/CreateContextHooks.java
+++ b/src/test/java/com/ragin/bdd/cucumbertests/hooks/CreateContextHooks.java
@@ -3,7 +3,6 @@ package com.ragin.bdd.cucumbertests.hooks;
 import com.ragin.bdd.Application;
 import com.ragin.bdd.cucumber.core.DatabaseExecutorService;
 import com.ragin.bdd.cucumber.utils.JsonUtils;
-import com.ragin.bdd.cucumbertests.library.test.Authentication;
 import io.cucumber.java.Before;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.Ignore;
@@ -20,9 +19,10 @@ import org.springframework.test.context.ContextConfiguration;
                 Application.class,
                 DatabaseExecutorService.class,
                 JsonUtils.class,
-                ParameterizedCustomScenarioContextMatcher.class,
                 SimpleCustomUUIDMatcher.class,
-                ParameterizedCustomMultiParameterMatcher.class
+                ParameterizedCustomScenarioContextMatcher.class,
+                ParameterizedCustomMultiParameterMatcher.class,
+                CustomDateTimeFormatter.class
         },
         loader = SpringBootContextLoader.class
 )

--- a/src/test/java/com/ragin/bdd/cucumbertests/hooks/CustomDateTimeFormatter.java
+++ b/src/test/java/com/ragin/bdd/cucumbertests/hooks/CustomDateTimeFormatter.java
@@ -1,0 +1,17 @@
+package com.ragin.bdd.cucumbertests.hooks;
+
+import com.ragin.bdd.cucumber.datetimeformat.BddCucumberDateTimeFormat;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Example to add a date with "yyyy.MM.dd" format.
+ */
+public class CustomDateTimeFormatter implements BddCucumberDateTimeFormat {
+    @Override
+    public List<String> pattern() {
+        return Collections.singletonList(
+                "yyyy.MM.dd"
+        );
+    }
+}

--- a/src/test/java/com/ragin/bdd/cucumbertests/library/test/CustomDateTime.java
+++ b/src/test/java/com/ragin/bdd/cucumbertests/library/test/CustomDateTime.java
@@ -1,0 +1,27 @@
+package com.ragin.bdd.cucumbertests.library.test;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CustomDateTime {
+    @GetMapping("/api/v1/customDateTime")
+    public ResponseEntity<String> stubCustomDateTime() {
+        return ResponseEntity.status(HttpStatus.OK).body(createCustomDateTime());
+    }
+
+
+    private String createCustomDateTime() {
+        final JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("validDate", "2020.04.30");
+        } catch (JSONException je) {
+        }
+
+        return jsonObject.toString();
+    }
+}

--- a/src/test/resources/features/body_validation/field_compare.feature
+++ b/src/test/resources/features/body_validation/field_compare.feature
@@ -72,3 +72,14 @@ Feature: Field validation instead of full JSON comparison
       | object.firstname | John                        |
       | object.lastname  | Doe                         |
       | shouldNotExist   | @bdd_lib_not_exist          |
+
+  Rule: It must be possible to add custom dateTime pattern and validate them with isValidDate()
+    Scenario: Validate a date in format "yyyy.MM.dd" with the configured custom dateTime pattern
+      When executing a GET call to "/api/v1/customDateTime"
+      Then I ensure that the status code of the response is 200
+      And I ensure that the body of the response is equal to
+      """
+      {
+      "validDate": "${json-unit.matches:isValidDate}"
+      }
+      """


### PR DESCRIPTION
## Dependencies
Update of dependencies and Cucumber library 6.8.1.

## Add own patterns for `${json-unit.matches:isValidDate}`
To add own `DateTimeFormatter` patterns to extend the `${json-unit.matches:isValidDate}` range
a new class is required that implements the interface `BddCucumberDateTimeFormat`.
The method `pattern()` must return the date patterns as `List<String>`.

To register this custom class it is necessary to add it `@ContextConfiguration` `classes` definition.

Example:

- [Configuration context](src/test/java/com/ragin/bdd/cucumbertests/hooks/CreateContextHooks.java)
- [Test feature](src/test/resources/features/body_validation/field_compare.feature)
