### PR TITLE
Database-less support in 1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
+# Release 1.29.0
+
+## Support for database-less applications
+This version introduces support for applications that do not have a database.
+To configure the library to run database-less, it is necessary to set up the following configuration in the `application.yaml` file:
+
+application.properties:
+```properties
+cucumberTest.databaseless=true
+```
+
+or
+
+application.yaml:
+```yaml
+cucumberTest:
+  databaseless: true
+```
+
+If the `databaseless` key is not true or missing, the library tries to instantiate the database related beans.
+
+In some cases it is required to disable the database autoconfiguration of Spring Boot:
+
+
+application.properties:
+```properties
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+```
+
+or
+
+application.yaml:
+```yaml
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+```
+
+or as annotation:
+
+```java
+@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
+@SpringBootApplication
+public class Application {
+  public static void main (String[] args) {
+    ApplicationContext ctx = SpringApplication.run(Application.class, args);
+  }
+}
+```
+
+Please also make sure that the `@ContextConfiguration` annotation does not contain the `DatabaseExecutorService.class`.
+
 # Release 1.28.0
 
 ## Proxy support

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ dependencies {
 - [Table of content](#table-of-content)
 - [Support JUnit 5](#support-junit-5)
 - [Base Configuration](#base-configuration)
+  - [Support for database-less applications](#support-for-database-less-applications)
   - [Base token definition](#base-token-definition)
   - [Base URL definition](#base-url-definition)
   - [Proxy support](#proxy-support)
@@ -100,6 +101,55 @@ testRuntimeOnly('org.junit.vintage:junit-vintage-engine') {
 ```
 
 # Base Configuration
+
+## Support for database-less applications
+To configure the library to run database-less, it is necessary to set up the following configuration in the `application.yaml` file:
+
+application.properties:
+```properties
+cucumberTest.databaseless=true
+```
+
+or
+
+application.yaml:
+```yaml
+cucumberTest:
+  databaseless: true
+```
+
+If the `databaseless` key is not true or missing, the library tries to instantiate the database related beans.
+
+In some cases it is required to disable the database autoconfiguration of Spring Boot:
+
+
+application.properties:
+```properties
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+```
+
+or
+
+application.yaml:
+```yaml
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+```
+
+or as annotation:
+
+```java
+@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
+@SpringBootApplication
+public class Application {
+  public static void main (String[] args) {
+    ApplicationContext ctx = SpringApplication.run(Application.class, args);
+  }
+}
+```
+
+Please also make sure that the `@ContextConfiguration` annotation does not contain the `DatabaseExecutorService.class`.
 
 ## Base token definition
 To define a default token those two parameters can be set in the properties:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.ragin.bdd
-version=1.28.0
+version=1.29.0
 
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github

--- a/src/main/kotlin/com/ragin/bdd/cucumber/core/DatabaseExecutorService.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/core/DatabaseExecutorService.kt
@@ -8,13 +8,12 @@ import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ClassLoaderResourceAccessor
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.stereotype.Service
 import javax.sql.DataSource
 
-@Service
-class DatabaseExecutorService(private val datasource: DataSource, private val jdbcTemplate: JdbcTemplate) {
+class DatabaseExecutorService(private val datasource: DataSource, private val jdbcTemplate: JdbcTemplate) :
+    IDatabaseExecutorService {
     @Value("\${cucumberTest.liquibase.closeConnection:false}")
-    private val closeConnection = false
+    val closeConnection = false
 
     /**
      * Execute Liquibase script
@@ -23,7 +22,7 @@ class DatabaseExecutorService(private val datasource: DataSource, private val jd
      * @throws Exception        Unable to execute liquibase script
      */
     @Throws(Exception::class)
-    fun executeLiquibaseScript(liquibaseScript: String) {
+    override fun executeLiquibaseScript(liquibaseScript: String) {
         val connection = JdbcConnection(datasource.connection)
         try {
             Liquibase(
@@ -49,7 +48,7 @@ class DatabaseExecutorService(private val datasource: DataSource, private val jd
      *
      * @param sql   SQL statements that should be executed
      */
-    fun executeSQL(sql: String) {
+    override fun executeSQL(sql: String) {
         jdbcTemplate.execute(sql)
     }
 
@@ -59,7 +58,7 @@ class DatabaseExecutorService(private val datasource: DataSource, private val jd
      * @param sql   SQL statements that should be executed
      * @return      List with a map per row which contains the result
      */
-    fun executeQuerySQL(sql: String): List<Map<String, Any>> {
+    override fun executeQuerySQL(sql: String): List<Map<String, Any>> {
         return jdbcTemplate.queryForList(sql)
     }
 }

--- a/src/main/kotlin/com/ragin/bdd/cucumber/core/IDatabaseExecutorService.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/core/IDatabaseExecutorService.kt
@@ -1,0 +1,30 @@
+package com.ragin.bdd.cucumber.core
+
+/**
+ * Interface for the DatabaseExecutorService
+ */
+interface IDatabaseExecutorService {
+    /**
+     * Execute Liquibase script
+     *
+     * @param liquibaseScript   path/filename of the Liquibase script
+     * @throws Exception        Unable to execute liquibase script
+     */
+    @Throws(Exception::class)
+    fun executeLiquibaseScript(liquibaseScript: String)
+
+    /**
+     * Execute SQL statements
+     *
+     * @param sql   SQL statements that should be executed
+     */
+    fun executeSQL(sql: String)
+
+    /**
+     * Execute an query of SQL statements
+     *
+     * @param sql   SQL statements that should be executed
+     * @return      List with a map per row which contains the result
+     */
+    fun executeQuerySQL(sql: String): List<Map<String, Any>>
+}

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/DatabaseGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/DatabaseGlue.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.ragin.bdd.cucumber.core.BaseCucumberCore
-import com.ragin.bdd.cucumber.core.DatabaseExecutorService
+import com.ragin.bdd.cucumber.core.IDatabaseExecutorService
 import com.ragin.bdd.cucumber.utils.JsonUtils
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
@@ -17,7 +17,7 @@ import java.util.stream.Collectors
 /**
  * This class contains database related steps.
  */
-open class DatabaseGlue(jsonUtils: JsonUtils, private val databaseExecutorService: DatabaseExecutorService) : BaseCucumberCore(jsonUtils) {
+open class DatabaseGlue(jsonUtils: JsonUtils, private val databaseExecutorService: IDatabaseExecutorService) : BaseCucumberCore(jsonUtils) {
     private val mapper = ObjectMapper()
 
     /**

--- a/src/main/kotlin/com/ragin/bdd/cucumber/hooks/ResetHooks.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/hooks/ResetHooks.kt
@@ -1,6 +1,6 @@
 package com.ragin.bdd.cucumber.hooks
 
-import com.ragin.bdd.cucumber.core.DatabaseExecutorService
+import com.ragin.bdd.cucumber.core.IDatabaseExecutorService
 import com.ragin.bdd.cucumber.core.ScenarioStateContext.addJsonIgnoringArrayOrder
 import com.ragin.bdd.cucumber.core.ScenarioStateContext.addJsonIgnoringExtraArrayElements
 import com.ragin.bdd.cucumber.core.ScenarioStateContext.addJsonIgnoringExtraFields
@@ -10,7 +10,7 @@ import io.cucumber.java.Scenario
 import org.apache.commons.logging.LogFactory
 import org.springframework.transaction.annotation.Transactional
 
-open class ResetHooks(private val databaseExecutorService: DatabaseExecutorService) {
+open class ResetHooks(private val databaseExecutorService: IDatabaseExecutorService) {
     companion object {
         private const val RESET_DATABASE_FILE = "database/reset_database.xml"
         private val log = LogFactory.getLog(ResetHooks::class.java)

--- a/src/main/kotlin/configuration/com/ragin/bdd/cucumber/glue/DatabaseExecutorServiceBeanConfig.kt
+++ b/src/main/kotlin/configuration/com/ragin/bdd/cucumber/glue/DatabaseExecutorServiceBeanConfig.kt
@@ -1,0 +1,55 @@
+package configuration.com.ragin.bdd.cucumber.glue
+
+import com.ragin.bdd.cucumber.core.DatabaseExecutorService
+import com.ragin.bdd.cucumber.core.IDatabaseExecutorService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.*
+import javax.sql.DataSource
+
+class DatabaseExecutorServiceBeanConfig(
+    private val dataSource: Optional<DataSource>,
+    private val jdbcTemplate: Optional<JdbcTemplate>
+) {
+    @Bean
+    @ConditionalOnProperty(
+        prefix = "cucumberTest",
+        name = ["databaseless"],
+        havingValue = "false",
+        matchIfMissing = true
+    )
+    fun databaseExecutorService(): IDatabaseExecutorService {
+        when {
+            dataSource.isEmpty -> {
+                throw IllegalArgumentException("""Missing bean: ${DataSource::class.qualifiedName}""")
+            }
+            jdbcTemplate.isEmpty -> {
+                throw IllegalArgumentException("""Missing bean: ${JdbcTemplate::class.qualifiedName}""")
+            }
+            else -> {
+                return DatabaseExecutorService(dataSource.get(), jdbcTemplate.get())
+            }
+        }
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        prefix = "cucumberTest",
+        name = ["databaseless"],
+        havingValue = "true",
+        matchIfMissing = false
+    )
+    fun databaseExec(): IDatabaseExecutorService {
+        return object : IDatabaseExecutorService {
+            @Throws(Exception::class)
+            override fun executeLiquibaseScript(liquibaseScript: String) {
+            }
+
+            override fun executeSQL(sql: String) {}
+            override fun executeQuerySQL(sql: String): List<Map<String, Any>> {
+                return Collections.emptyList()
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  configuration.com.ragin.bdd.cucumber.glue.DatabaseExecutorServiceBeanConfig


### PR DESCRIPTION
# Support for database-less applications
This version introduces support for applications that do not have a database.
To configure the library to run database-less, it is necessary to set up the following configuration in the `application.yaml` file:

application.properties:
```properties
cucumberTest.databaseless=true
```

or

application.yaml:
```yaml
cucumberTest:
  databaseless: true
```

If the `databaseless` key is not true or missing, the library tries to instantiate the database related beans.

In some cases it is required to disable the database autoconfiguration of Spring Boot:


application.properties:
```properties
spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
```

or

application.yaml:
```yaml
spring:
  autoconfigure:
    exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
```

or as annotation:

```java
@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class, HibernateJpaAutoConfiguration.class})
@SpringBootApplication
public class Application {
  public static void main (String[] args) {
    ApplicationContext ctx = SpringApplication.run(Application.class, args);
  }
}
```

Please also make sure that the `@ContextConfiguration` annotation does not contain the `DatabaseExecutorService.class`.
