### PR TITLE
Release polling 1.30.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,74 @@
+# Release 1.30.0
+## Support for polling APIs
+The polling configuration is automatically reset before each scenario.
+It can be configured via the background or directly in the scenario.
+
+When the expected HTTP status code and JSON structure has been sent as a response, polling will stop.
+This allows an endpoint to be polled until it changes state or fail if the state has not changed during the specified time and retry configuration.
+
+The configuration can be done in to ways.
+
+As a single line configuration:
+```gherkin
+Scenario: Single line configuration
+    Given that a request polls every 1 seconds for 5 times
+```
+
+Or as a multiline configuration that supports to specify one of the configurations in the `Background` and the other in the `Scenario` (or to have it more readable).
+
+```gherkin
+Scenario: Multiline configuration
+    Given that a requests polls every 1 seconds
+    And that a requests polls for 5 times
+```
+
+The `URL`/`URI` and (if required) body have to be preconfigured. Polling itself does simply use previous set body and path definition.
+To execute a request it supports the well known authorized and unauthorized phrases and it supports direct JSON or JSON from file:
+
+Authorized request with JSON response file:
+```gherkin
+Scenario: Authorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing an authorized GET poll request until the response code is 200 and the body is equal to file "expected.json"
+```
+
+Unauthorized request with JSON response file:
+```gherkin
+Scenario: Unauthorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing a GET poll request until the response code is 200 and the body is equal to file "expected.json"
+```
+
+Authorized request with direct JSON response:
+```gherkin
+Scenario: Authorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing an authorized GET poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """
+```
+
+Unauthorized request with direct JSON response:
+```gherkin
+Scenario: Unauthorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing a GET poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """
+```
+
+Examples can be found at [src/test/resources/features/polling/](src/test/resources/features/polling/).
+
 # Release 1.29.1
 
 ## Support for database-less applications

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ dependencies {
   - [REST](#rest)
     - [JSON-Unit](#json-unit)
       - [Adding own pattern for `${json-unit.matches:isValidDate}`](#adding-own-pattern-for-json-unitmatchesisvaliddate)
+    - [Polling](#polling)
     - [Given](#given-1)
       - [Define user(s)](#define-users)
       - [Set path base directory for request/result/database files](#set-path-base-directory-for-requestresultdatabase-files)
@@ -375,6 +376,78 @@ Example:
 
 - [Configuration context](src/test/java/com/ragin/bdd/cucumbertests/hooks/CreateContextHooks.java)
 - [Test feature](src/test/resources/features/body_validation/field_compare.feature)
+
+### Polling
+Polling support combines some `Given` and `When` definitions. For this reason it has its own chapter.
+
+The polling configuration is automatically reset before each scenario.
+It can be configured via the background or directly in the scenario.
+
+When the expected HTTP status code and JSON structure has been sent as a response, polling will stop.
+This allows an endpoint to be polled until it changes state or fail if the state has not changed during the specified time and retry configuration.
+
+The configuration can be done in to ways.
+
+As a single line configuration:
+```gherkin
+Scenario: Single line configuration
+    Given that a request polls every 1 seconds for 5 times
+```
+
+Or as a multiline configuration that supports to specify one of the configurations in the `Background` and the other in the `Scenario` (or to have it more readable).
+
+```gherkin
+Scenario: Multiline configuration
+    Given that a requests polls every 1 seconds
+    And that a requests polls for 5 times
+```
+
+The `URL`/`URI` and (if required) body have to be preconfigured. Polling itself does simply use previous set body and path definition.
+To execute a request it supports the well known authorized and unauthorized phrases and it supports direct JSON or JSON from file:
+
+Authorized request with JSON response file:
+```gherkin
+Scenario: Authorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing an authorized GET poll request until the response code is 200 and the body is equal to file "expected.json"
+```
+
+Unauthorized request with JSON response file:
+```gherkin
+Scenario: Unauthorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing a GET poll request until the response code is 200 and the body is equal to file "expected.json"
+```
+
+Authorized request with direct JSON response:
+```gherkin
+Scenario: Authorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing an authorized GET poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """
+```
+
+Unauthorized request with direct JSON response:
+```gherkin
+Scenario: Unauthorized request with JSON response file
+  Given that a request polls every 1 seconds for 5 times
+  And that the API path is "/api/v1/polling"
+  When executing a GET poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """
+```
+
+Examples can be found at [src/test/resources/features/polling/](src/test/resources/features/polling/).
 
 
 ### Given

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.ragin.bdd
-version=1.29.2
+version=1.30.0
 
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github
@@ -7,7 +7,7 @@ systemProp.sonar.projectKey=Ragin-LundF_bbd-cucumber-gherkin-lib
 
 versionJavaxJson=1.1.4
 versionJsonUnit=2.24.0
-versionCucumber=6.9.1
+versionCucumber=6.10.1
 versionValidationApi=2.0.1.Final
 versionCommonsText=1.9
 versionCommonsIo=2.8.0

--- a/src/main/kotlin/com/ragin/bdd/cucumber/core/ScenarioStateContext.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/core/ScenarioStateContext.kt
@@ -17,6 +17,7 @@ object ScenarioStateContext {
     var userTokenMap: HashMap<String, String> = HashMap()
     private var jsonPathOptions: MutableList<Option> = ArrayList(0)
     var executionTime = -1L
+    var polling = Polling()
 
     /**
      * Add IGNORING_EXTRA_ARRAY_ITEMS option to the jsonPathOptions
@@ -51,6 +52,7 @@ object ScenarioStateContext {
         headerValues = HashMap()
         jsonPathOptions = ArrayList(0)
         bearerToken = defaultBearerToken
+        polling = Polling()
     }
 
     fun getJsonPathOptions(): List<Option> {
@@ -64,5 +66,10 @@ object ScenarioStateContext {
     @JvmStatic
     fun current() : ScenarioStateContext {
         return this
+    }
+
+    class Polling {
+        var pollEverySeconds : Long = 0
+        var numberOfPolls : Int = -1
     }
 }

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/GivenRESTStateGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/GivenRESTStateGlue.kt
@@ -172,4 +172,20 @@ class GivenRESTStateGlue(jsonUtils: JsonUtils) : BaseCucumberCore(jsonUtils) {
             ScenarioStateContext.bearerToken = bearerFromContext
         }
     }
+
+    @Given("that a requests polls every {int} seconds")
+    fun givenPollingSeconds(seconds: Long) {
+        ScenarioStateContext.polling.pollEverySeconds = seconds
+    }
+
+    @Given("that a requests polls for {int} times")
+    fun givenPollingNumberOfPolls(numberOfPolls: Int) {
+        ScenarioStateContext.polling.numberOfPolls = numberOfPolls
+    }
+
+    @Given("that a request polls every {int} seconds for {int} times")
+    fun givenPollingSecondsAndNumberOfPolls(seconds: Long, numberOfPolls: Int) {
+        ScenarioStateContext.polling.pollEverySeconds = seconds
+        ScenarioStateContext.polling.numberOfPolls = numberOfPolls
+    }
 }

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/ThenRESTValidationGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/ThenRESTValidationGlue.kt
@@ -15,6 +15,7 @@ import java.io.IOException
  * This class contains HTTP response validations.
  */
 class ThenRESTValidationGlue(jsonUtils: JsonUtils) : BaseCucumberCore(jsonUtils) {
+
     /**
      * Ensure, that the response code is valid
      * @param expectedStatusCode HTTP status code that is expected

--- a/src/test/java/com/ragin/bdd/cucumbertests/library/test/Polling.java
+++ b/src/test/java/com/ragin/bdd/cucumbertests/library/test/Polling.java
@@ -1,0 +1,69 @@
+package com.ragin.bdd.cucumbertests.library.test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Data;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Polling {
+    private static final AtomicInteger RUN_COUNTER_POLLING = new AtomicInteger(0);
+
+    @GetMapping("/api/v1/polling")
+    public ResponseEntity<String> polling() {
+        if (RUN_COUNTER_POLLING.incrementAndGet() < 3) {
+            return ResponseEntity.ok().body(createMessage("NOT_READY"));
+        }
+        RUN_COUNTER_POLLING.set(0);
+        return ResponseEntity.ok().body(createMessage("SUCCESSFUL"));
+    }
+
+    @GetMapping("/api/v1/pollingAuth")
+    public ResponseEntity<String> pollingAuthorized(final @NonNull @RequestHeader("Authorization") String authToken) {
+        if (StringUtils.isEmpty(authToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(createMessage("UNAUTHORIZED"));
+        }
+
+        if (RUN_COUNTER_POLLING.incrementAndGet() < 3) {
+            return ResponseEntity.ok().body(createMessage("NOT_READY"));
+        }
+        RUN_COUNTER_POLLING.set(0);
+        return ResponseEntity.ok().body(createMessage("SUCCESSFUL"));
+    }
+
+    @PostMapping("/api/v1/polling")
+    public ResponseEntity<String> pollingPost(@RequestBody PollingRequest body) {
+        if (RUN_COUNTER_POLLING.incrementAndGet() < 3) {
+            return ResponseEntity.status(HttpStatus.TOO_EARLY).body(createMessage("NOT_READY"));
+        }
+        RUN_COUNTER_POLLING.set(0);
+        if (StringUtils.isEmpty(body.getPostExample())) {
+            return ResponseEntity.badRequest().body(createMessage("INVALID PARAMETER"));
+        }
+        return ResponseEntity.ok().body(createMessage("SUCCESSFUL"));
+    }
+
+    private String createMessage(final String message) {
+        final JSONObject jsonObject = new JSONObject();
+        try {
+            jsonObject.put("message", message);
+        } catch (JSONException ignored) {
+        }
+
+        return jsonObject.toString();
+    }
+
+    @Data
+    public static class PollingRequest {
+        String postExample;
+    }
+}

--- a/src/test/resources/features/polling/polling.feature
+++ b/src/test/resources/features/polling/polling.feature
@@ -1,0 +1,51 @@
+Feature: Polling test
+  Background:
+    Given that all file paths are relative to "features/polling/responses/"
+
+  Scenario: Polling unauthorized until response is correct with long config
+    Given that a requests polls every 1 seconds
+    And that a requests polls for 5 times
+    And that the API path is "/api/v1/polling"
+    When executing a GET poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """
+
+  Scenario: Polling authorized until response is correct with short config
+    Given that a request polls every 1 seconds for 5 times
+    And that the API path is "/api/v1/pollingAuth"
+    When executing an authorized GET poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """
+
+  Scenario: Polling unauthorized until response is equal to a file with long config
+    Given that a requests polls every 1 seconds
+    And that a requests polls for 5 times
+    And that the API path is "/api/v1/polling"
+    When executing a GET poll request until the response code is 200 and the body is equal to file "expected.json"
+
+  Scenario: Polling authorized until response is equal to a file with short config
+    Given that a request polls every 1 seconds for 5 times
+    And that the API path is "/api/v1/pollingAuth"
+    When executing an authorized GET poll request until the response code is 200 and the body is equal to file "expected.json"
+
+  Scenario: Polling with body until response is correct with short config
+    Given that a request polls every 1 seconds for 5 times
+    And that the API path is "/api/v1/polling"
+    And that the body of the request is
+    """
+    {
+      "postExample": "myBody"
+    }
+    """
+    When executing an authorized POST poll request until the response code is 200 and the body is equal to
+    """
+    {
+      "message": "SUCCESSFUL"
+    }
+    """

--- a/src/test/resources/features/polling/responses/expected.json
+++ b/src/test/resources/features/polling/responses/expected.json
@@ -1,0 +1,3 @@
+{
+  "message": "SUCCESSFUL"
+}


### PR DESCRIPTION
## Support for polling APIs
The polling configuration is automatically reset before each scenario.
It can be configured via the background or directly in the scenario.

When the expected HTTP status code and JSON structure has been sent as a response, polling will stop.
This allows an endpoint to be polled until it changes state or fail if the state has not changed during the specified time and retry configuration.

The configuration can be done in to ways.

As a single line configuration:
```gherkin
Scenario: Single line configuration
    Given that a request polls every 1 seconds for 5 times
```

Or as a multiline configuration that supports to specify one of the configurations in the `Background` and the other in the `Scenario` (or to have it more readable).

```gherkin
Scenario: Multiline configuration
    Given that a requests polls every 1 seconds
    And that a requests polls for 5 times
```

The `URL`/`URI` and (if required) body have to be preconfigured. Polling itself does simply use previous set body and path definition.
To execute a request it supports the well known authorized and unauthorized phrases and it supports direct JSON or JSON from file:

Authorized request with JSON response file:
```gherkin
Scenario: Authorized request with JSON response file
  Given that a request polls every 1 seconds for 5 times
  And that the API path is "/api/v1/polling"
  When executing an authorized GET poll request until the response code is 200 and the body is equal to file "expected.json"
```

Unauthorized request with JSON response file:
```gherkin
Scenario: Unauthorized request with JSON response file
  Given that a request polls every 1 seconds for 5 times
  And that the API path is "/api/v1/polling"
  When executing a GET poll request until the response code is 200 and the body is equal to file "expected.json"
```

Authorized request with direct JSON response:
```gherkin
Scenario: Authorized request with JSON response file
  Given that a request polls every 1 seconds for 5 times
  And that the API path is "/api/v1/polling"
  When executing an authorized GET poll request until the response code is 200 and the body is equal to
    """
    {
      "message": "SUCCESSFUL"
    }
    """
```

Unauthorized request with direct JSON response:
```gherkin
Scenario: Unauthorized request with JSON response file
  Given that a request polls every 1 seconds for 5 times
  And that the API path is "/api/v1/polling"
  When executing a GET poll request until the response code is 200 and the body is equal to
    """
    {
      "message": "SUCCESSFUL"
    }
    """
```

Examples can be found at [src/test/resources/features/polling/](src/test/resources/features/polling/).
