### PR TITLE
Release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Release 2.7.0
+## Updated Libs
+- Spring Boot to 3.1.4
+- Cucumber Libs to 7.14.0
+- json-unit to 3.2.2
+- liquibase-core to 4.24.0
+
+## Features
+Added a new default matcher (`${json-unit.matches:isNotEqualToScenarioContext}MY_CONTEXT_VALUE`) to compare, that a value is not equal to the context:
+
+```gherkin
+    And I ensure that the body of the response is equal to
+      """ 
+        {
+          "value": "${json-unit.matches:isNotEqualToScenarioContext}MY_CONTEXT_VALUE",
+        }
+      """
+```
+
 # Release 2.6.1
 Small fix for URL encoded calls, to be able to leave a value empty if the parameters are dynamic.
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@ plugins {
     id "signing"
     id "java-library"
     id "maven-publish"
-    id "org.springframework.boot" version "3.1.3"
+    id "org.springframework.boot" version "3.1.4"
     id "io.spring.dependency-management" version "1.1.3"
     id "org.liquibase.gradle" version "2.2.0"
-    id "org.sonarqube" version "4.3.0.3225"
+    id "org.sonarqube" version "4.4.1.3373"
 }
 
 apply plugin: 'kotlin'
@@ -37,21 +37,21 @@ configurations.configureEach {
 dependencies {
     api "org.apache.httpcomponents.client5:httpclient5:5.2.1"
 
-    api "net.javacrumbs.json-unit:json-unit:3.0.0"
+    api "net.javacrumbs.json-unit:json-unit:3.2.2"
 
-    api "io.cucumber:cucumber-java:7.13.0"
-    api "io.cucumber:cucumber-spring:7.13.0"
-    api "io.cucumber:cucumber-junit:7.13.0"
+    api "io.cucumber:cucumber-java:7.14.0"
+    api "io.cucumber:cucumber-spring:7.14.0"
+    api "io.cucumber:cucumber-junit:7.14.0"
 
     api "jakarta.validation:jakarta.validation-api:3.0.2"
 
     api "org.apache.commons:commons-text:1.10.0"
-    implementation "commons-io:commons-io:2.13.0"
+    implementation "commons-io:commons-io:2.14.0"
     implementation "org.apache.commons:commons-lang3:3.13.0"
 
     // Defining the version here, because Spring brings 4.5.0, which has a CVE
     implementation "org.yaml:snakeyaml:2.2"
-    implementation "org.liquibase:liquibase-core:4.23.0"
+    implementation "org.liquibase:liquibase-core:4.24.0"
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-test"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
@@ -62,15 +62,15 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    compileOnly "org.projectlombok:lombok:1.18.28"
-    annotationProcessor "org.projectlombok:lombok:1.18.28"
-    testCompileOnly "org.projectlombok:lombok:1.18.28"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.28"
+    compileOnly "org.projectlombok:lombok:1.18.30"
+    annotationProcessor "org.projectlombok:lombok:1.18.30"
+    testCompileOnly "org.projectlombok:lombok:1.18.30"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
 
     testImplementation "org.postgresql:postgresql:42.6.0"
-    testImplementation "org.testcontainers:testcontainers:1.19.0"
-    testImplementation "org.testcontainers:postgresql:1.19.0"
-    testImplementation "org.testcontainers:junit-jupiter:1.19.0"
+    testImplementation "org.testcontainers:testcontainers:1.19.1"
+    testImplementation "org.testcontainers:postgresql:1.19.1"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.1"
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.ragin-lundf
-version=2.6.1
+version=2.7.0
 
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/BaseRESTExecutionGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/BaseRESTExecutionGlue.kt
@@ -241,7 +241,9 @@ abstract class BaseRESTExecutionGlue(
             if (! list["Value"].isNullOrEmpty()) {
                 val key = scenarioContextMap[list["Key"]] ?: list["Key"]
                 val value = scenarioContextMap[list["Value"]] ?: list["Value"]
-                map.add(key, value)
+                if (! key.isNullOrEmpty() && ! value.isNullOrEmpty()) {
+                    map.add(key, value)
+                }
             }
         }
 

--- a/src/main/kotlin/com/ragin/bdd/cucumber/matcher/ScenarioStateEqContextMatcher.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/matcher/ScenarioStateEqContextMatcher.kt
@@ -7,7 +7,7 @@ import org.hamcrest.Description
 import org.springframework.stereotype.Component
 
 @Component
-class ScenarioStateContextMatcher : BaseMatcher<Any>(), ParametrizedMatcher {
+class ScenarioStateEqContextMatcher : BaseMatcher<Any>(), ParametrizedMatcher {
     private var parameter: String? = null
 
     override fun matches(actual: Any): Boolean {

--- a/src/main/kotlin/com/ragin/bdd/cucumber/matcher/ScenarioStateNeContextMatcher.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/matcher/ScenarioStateNeContextMatcher.kt
@@ -1,0 +1,36 @@
+package com.ragin.bdd.cucumber.matcher
+
+import com.ragin.bdd.cucumber.core.ScenarioStateContext
+import net.javacrumbs.jsonunit.core.ParametrizedMatcher
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.springframework.stereotype.Component
+
+@Component
+class ScenarioStateNeContextMatcher : BaseMatcher<Any>(), ParametrizedMatcher {
+    private var parameter: String? = null
+
+    override fun matches(actual: Any): Boolean {
+        val parameterFromContext = ScenarioStateContext.scenarioContextMap[parameter]
+        val actualAsString = actual.toString()
+        return actualAsString != parameterFromContext
+    }
+
+    override fun describeTo(description: Description) {
+        description.appendText("The actual value is equal to the parameter [$parameter]")
+    }
+
+    override fun describeMismatch(item: Any, description: Description) {
+        description
+                .appendText("BDD Context value was [")
+                .appendValue(ScenarioStateContext.scenarioContextMap[parameter])
+                .appendText("].")
+                .appendText(" JSON Value was [")
+                .appendValue(item)
+                .appendText("].")
+    }
+
+    override fun setParameter(parameter: String) {
+        this.parameter = parameter
+    }
+}

--- a/src/main/kotlin/com/ragin/bdd/cucumber/utils/JsonUtils.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/utils/JsonUtils.kt
@@ -8,13 +8,11 @@ import com.ragin.bdd.cucumber.core.ScenarioStateContext.scenarioContextMap
 import com.ragin.bdd.cucumber.datetimeformat.BddCucumberDateTimeFormat
 import com.ragin.bdd.cucumber.matcher.BddCucumberJsonMatcher
 import com.ragin.bdd.cucumber.matcher.IBANMatcher
-import com.ragin.bdd.cucumber.matcher.ScenarioStateContextMatcher
+import com.ragin.bdd.cucumber.matcher.ScenarioStateEqContextMatcher
+import com.ragin.bdd.cucumber.matcher.ScenarioStateNeContextMatcher
 import com.ragin.bdd.cucumber.matcher.UUIDMatcher
 import com.ragin.bdd.cucumber.matcher.ValidDateContextMatcher
 import com.ragin.bdd.cucumber.matcher.ValidDateMatcher
-import java.util.Arrays
-import java.util.Optional
-import java.util.stream.Collectors
 import net.javacrumbs.jsonunit.JsonAssert
 import net.javacrumbs.jsonunit.core.Configuration
 import net.javacrumbs.jsonunit.core.Option
@@ -22,6 +20,8 @@ import org.apache.commons.logging.LogFactory
 import org.hamcrest.Matcher
 import org.junit.Assert
 import org.springframework.stereotype.Component
+import java.util.*
+import java.util.stream.Collectors
 
 /**
  * Utility class used to work with JSON objects.
@@ -70,7 +70,8 @@ class JsonUtils(
                 .withMatcher("isDateOfContext", ValidDateContextMatcher(bddCucumberDateTimeFormatter))
                 .withMatcher("isValidUUID", UUIDMatcher())
                 .withMatcher("isValidIBAN", IBANMatcher())
-                .withMatcher("isEqualToScenarioContext", ScenarioStateContextMatcher())
+                .withMatcher("isEqualToScenarioContext", ScenarioStateEqContextMatcher())
+                .withMatcher("isNotEqualToScenarioContext", ScenarioStateNeContextMatcher())
 
         // add additional options
         for (jsonOption in getJsonPathOptions()) {

--- a/src/test/resources/features/body_manipulation/body_manipulation.feature
+++ b/src/test/resources/features/body_manipulation/body_manipulation.feature
@@ -56,6 +56,7 @@ Feature: Manipulation of the body
   Scenario: Manipulate the body from a context variable and compare it by context matcher
     Given that the file "requests/request.json" is used as the body
         * that the context contains the key "newUserNameInContext" with the value "Max Done"
+        * that the context contains the key "wrongUserNameInContext" with the value "Max False"
         * that the context contains the key "secondEntry" with the value "unknown"
     Then I set the value of the previously given body property "name" to "newUserNameInContext"
        * I set the value of the previously given body property "ids[1]" to "secondEntry"
@@ -74,6 +75,17 @@ Feature: Manipulation of the body
       ]
     }
     """
+    And I ensure that the body of the response is equal to
+        """
+        {
+          "newName": "${json-unit.matches:isNotEqualToScenarioContext}wrongUserNameInContext",
+          "newIds" : [
+            "first",
+            "${json-unit.matches:isEqualToScenarioContext}secondEntry",
+            "thirdEntry"
+          ]
+        }
+        """
 
 
   Scenario: Manipulate the body and remove the name


### PR DESCRIPTION
# Updated Libs
- Spring Boot to 3.1.4
- Cucumber Libs to 7.14.0
- json-unit to 3.2.2
- liquibase-core to 4.24.0

# Features
Added a new default matcher (`${json-unit.matches:isNotEqualToScenarioContext}MY_CONTEXT_VALUE`) to compare, that a value is not equal to the context:

```gherkin
    And I ensure that the body of the response is equal to
      """ 
        {
          "value": "${json-unit.matches:isNotEqualToScenarioContext}MY_CONTEXT_VALUE",
        }
      """
```
