### PR TITLE
Release 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Release 2.17.0
+The configuration
+```yaml
+cucumberTest:
+  authorization:
+    ...
+```
+is no longer required.
+It must be set, if a default token can be used. Else the token must be provided via `Background` or inside of the `Scenario`.
+
 # Release 2.16.0
 - Spring Boot to 3.3.3
 - liquibase-core to 4.29.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.ragin-lundf
-version=2.16.0
+version=2.17.0
 jdk_version=17
 kotlin_version=1.9.23
 

--- a/src/main/kotlin/com/ragin/bdd/cucumber/config/BddProperties.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/config/BddProperties.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "cucumbertest")
 data class BddProperties(
-    val authorization : Authorization,
+    val authorization : Authorization?,
     val proxy : Proxy?,
     val server: Server?,
     val ssl : SSL?,
@@ -17,8 +17,8 @@ data class BddProperties(
          * Authorization
          */
         data class AuthorizationBearer(
-            val default : String,
-            val noscope: String
+            val default : String? = null,
+            val noscope: String? = null,
         )
     }
 

--- a/src/main/kotlin/com/ragin/bdd/cucumber/core/BaseCucumberCore.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/core/BaseCucumberCore.kt
@@ -18,8 +18,8 @@ open class BaseCucumberCore(protected val jsonUtils: JsonUtils, protected val bd
      * @param defaultBearerToken default Bearer token
      */
     fun setDefaultBearerToken(defaultBearerToken: String?) {
-        if (bddProperties.authorization.bearerToken.default.isNotEmpty()) {
-            ScenarioStateContext.defaultBearerToken = bddProperties.authorization.bearerToken.default
+        if (bddProperties.authorization?.bearerToken?.default.isNullOrEmpty().not()) {
+            ScenarioStateContext.defaultBearerToken = bddProperties.authorization!!.bearerToken.default!!
         }
         bearerToken = bearerToken ?: defaultBearerToken
     }

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/BaseRESTExecutionGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/BaseRESTExecutionGlue.kt
@@ -53,8 +53,8 @@ abstract class BaseRESTExecutionGlue(
     init {
         // init ScenarioContext
         bddProperties.scenarioContext.let { scenarioContextMap.putAll(it) }
-        if (bddProperties.authorization.bearerToken.default.isNotEmpty()) {
-            setDefaultBearerToken(bddProperties.authorization.bearerToken.default)
+        if (bddProperties.authorization?.bearerToken?.default.isNullOrEmpty().not()) {
+            setDefaultBearerToken(bddProperties.authorization!!.bearerToken.default)
         }
 
         // https://stackoverflow.com/questions/16748969/java-net-httpretryexception-cannot-retry-due-to-server-authentication-in-strea

--- a/src/test/kotlin/com/ragin/bdd/cucumbertests/library/test/Authentication.kt
+++ b/src/test/kotlin/com/ragin/bdd/cucumbertests/library/test/Authentication.kt
@@ -48,7 +48,7 @@ class Authentication(
     fun stubAuthenticatedWithTokenGet(
         @RequestHeader("Authorization") authToken: String
     ): ResponseEntity<String> {
-        if (authToken == BEARER + bddProperties.authorization.bearerToken.default) {
+        if (authToken == BEARER + bddProperties.authorization?.bearerToken?.default) {
             return ResponseEntity.ok().body(createAuthorizedResponse())
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(createUnauthorizedResponse())
@@ -59,7 +59,7 @@ class Authentication(
         @RequestHeader("Authorization") authToken: String,
         @RequestBody body: String?
     ): ResponseEntity<String> {
-        if (authToken == BEARER + bddProperties.authorization.bearerToken.default) {
+        if (authToken == BEARER + bddProperties.authorization?.bearerToken?.default) {
             return ResponseEntity.ok().body(createAuthorizedResponse())
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(createUnauthorizedResponse())
@@ -70,7 +70,7 @@ class Authentication(
         @RequestHeader("Authorization") authToken: String,
         @RequestBody body: String?
     ): ResponseEntity<String> {
-        if (authToken == BEARER + bddProperties.authorization.bearerToken.default) {
+        if (authToken == BEARER + bddProperties.authorization?.bearerToken?.default) {
             return ResponseEntity.ok().body(createAuthorizedResponse())
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(createUnauthorizedResponse())
@@ -81,7 +81,7 @@ class Authentication(
         @RequestHeader("Authorization") authToken: String,
         @RequestBody body: String?
     ): ResponseEntity<String> {
-        if (authToken == BEARER + bddProperties.authorization.bearerToken.default) {
+        if (authToken == BEARER + bddProperties.authorization?.bearerToken?.default) {
             return ResponseEntity.ok().body(createAuthorizedResponse())
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(createUnauthorizedResponse())
@@ -92,7 +92,7 @@ class Authentication(
         @RequestHeader("Authorization") authToken: String,
         @RequestBody body: String?
     ): ResponseEntity<String> {
-        if (authToken == BEARER + bddProperties.authorization.bearerToken.default) {
+        if (authToken == BEARER + bddProperties.authorization?.bearerToken?.default) {
             return ResponseEntity.ok().body(createAuthorizedResponse())
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(createUnauthorizedResponse())


### PR DESCRIPTION
The configuration
```yaml
cucumberTest:
  authorization:
    ...
```
is no longer required.
It must be set, if a default token can be used. Else the token must be provided via `Background` or inside of the `Scenario`.
