### PR TITLE
Release 2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Release 2.23.0
+## New sentence to set a proxy for the communication at "runtime"
+
+This introduces a sentence for dynamic proxy settings.
+
+```gherkin
+Given that a proxy with host "<string>" and port "<string>" is configured
+```
+Both the host and the port can either be the host/proxy or a variable from the `ScenarioStateContext`.
+
+This helps, for example, to set proxies started via test containers (e.g. Burp Scanner or Mock Server) during the test.
+This way it is not necessary to assign a fixed port to the proxy.
+This can then be written in another sentence or after starting a proxy container in the `ScenarioContext`.
+
+Alternatively, the proxy can also be written directly to the `ScenarioStateContext`:
+
+```kotlin
+ScenarioStateContext.current().dynamicProxyHost = "localhost"
+ScenarioStateContext.current().dynamicProxyPort = "8808"
+```
+
+
 # Release 2.22.0
 ## Fixes
 The SSL configuration has returned a wrong HTTP client configuration, which was not ignoring redirects from the server.

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "signing"
     id "java-library"
     id "maven-publish"
-    id "org.sonarqube" version "6.0.1.5171"
+    id "org.sonarqube" version "6.0.1.5360"
     id "io.gitlab.arturbosch.detekt" version "1.23.8"
     id "org.springframework.boot" version "3.4.4"
     id "io.spring.dependency-management" version "1.1.7"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.ragin-lundf
-version=2.22.0
+version=2.23.0
 jdk_version=17
 kotlin_version=2.0.21
 

--- a/src/main/kotlin/com/ragin/bdd/cucumber/core/ScenarioStateContext.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/core/ScenarioStateContext.kt
@@ -17,6 +17,8 @@ object ScenarioStateContext {
     var userTokenMap: HashMap<String, String> = hashMapOf()
     private var jsonPathOptions: MutableList<Option> = mutableListOf()
     var executionTime = -1L
+    var dynamicProxyHost: String? = null
+    var dynamicProxyPort: Int? = null
     var polling = Polling()
 
     /**

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/BaseRESTExecutionGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/BaseRESTExecutionGlue.kt
@@ -46,7 +46,7 @@ import java.net.Proxy
 abstract class BaseRESTExecutionGlue(
     jsonUtils: JsonUtils,
     bddProperties: BddProperties,
-    private val restTemplate: TestRestTemplate
+    val restTemplate: TestRestTemplate
 ) : BaseCucumberCore(
     jsonUtils = jsonUtils,
     bddProperties = bddProperties
@@ -86,7 +86,7 @@ abstract class BaseRESTExecutionGlue(
     }
 
     @Suppress("ComplexCondition")
-    protected fun createHttpClient(): CloseableHttpClient {
+    protected fun createHttpClient(proxyHost: String? = null, proxyPort: Int? = null): CloseableHttpClient {
         val httpClientBuilder = HttpClientBuilder.create()
         httpClientBuilder.disableRedirectHandling()
 
@@ -104,15 +104,26 @@ abstract class BaseRESTExecutionGlue(
             httpClientBuilder.setConnectionManager(connectionManager)
         }
 
+        var proxyHostUsed: String? = null
+        var proxyPortUsed: Int? = null
         if (bddProperties.proxy != null
             && !StringUtils.isEmpty(bddProperties.proxy.host)
             && bddProperties.proxy.port != null && bddProperties.proxy.port > 0
         ) {
+            proxyHostUsed = bddProperties.proxy.host
+            proxyPortUsed = bddProperties.proxy.port
+        }
+        if (proxyHost != null && proxyPort != null) {
+            proxyHostUsed = proxyHost
+            proxyPortUsed = proxyPort
+        }
+
+        if (ScenarioStateContext.dynamicProxyHost != null && ScenarioStateContext.dynamicProxyPort != null) {
             httpClientBuilder.setProxy(
                 HttpHost(
                     Proxy.Type.HTTP.name,
-                    bddProperties.proxy.host,
-                    bddProperties.proxy.port,
+                    ScenarioStateContext.dynamicProxyHost,
+                    ScenarioStateContext.dynamicProxyPort!!,
                 )
             )
         }

--- a/src/main/kotlin/com/ragin/bdd/cucumber/glue/WhenRESTExecutionGlue.kt
+++ b/src/main/kotlin/com/ragin/bdd/cucumber/glue/WhenRESTExecutionGlue.kt
@@ -9,6 +9,7 @@ import io.cucumber.datatable.DataTable
 import io.cucumber.java.Before
 import io.cucumber.java.ParameterType
 import io.cucumber.java.Scenario
+import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -36,6 +37,16 @@ class WhenRESTExecutionGlue(
     @Before
     fun injectScenario(scenario: Scenario) {
         scenarioState = scenario
+    }
+
+    @Given("that a proxy with host {string} and port {string} is configured")
+    fun givenProxy(host: String, port: String) {
+        val finalHost = ScenarioStateContext.resolveEntry(key = host)
+        val finalPort = ScenarioStateContext.resolveEntry(key = port).toInt()
+
+        ScenarioStateContext.dynamicProxyHost = finalHost
+        ScenarioStateContext.dynamicProxyPort = finalPort
+        restTemplate.restTemplate.requestFactory = createRequestFactory()
     }
 
     /**


### PR DESCRIPTION
## New sentence to set a proxy for the communication at "runtime"

This introduces a sentence for dynamic proxy settings.

```gherkin
Given that a proxy with host "<string>" and port "<string>" is configured
```
Both the host and the port can either be the host/proxy or a variable from the `ScenarioStateContext`.

This helps, for example, to set proxies started via test containers (e.g. Burp Scanner or Mock Server) during the test.
This way it is not necessary to assign a fixed port to the proxy.
This can then be written in another sentence or after starting a proxy container in the `ScenarioContext`.

Alternatively, the proxy can also be written directly to the `ScenarioStateContext`:

```kotlin
ScenarioStateContext.current().dynamicProxyHost = "localhost"
ScenarioStateContext.current().dynamicProxyPort = "8808"
```
